### PR TITLE
Add pragma once and improve code style.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,13 @@ See the [Tello SDK 2.0 User Guide](https://dl-cdn.ryzerobotics.com/downloads/Tel
 ## Dependencies
 This project was developed and tested with the versions listed below.
 
-| Name        | Version                |
-|-------------|:----------------------:|
-|C++          | 17                     |
-|C++ compiler | GCC 9.3.0, Clang 9.0.1 |
-|CMake        | 3.17                   |
-|spdlog       | 1.5.0-1                |
-|OpenCV       | 4.2.0-2                |
+| Name         |        Version         |
+|--------------|:----------------------:|
+| C++          |           17           |
+| C++ compiler | GCC 9.3.0, Clang 9.0.1 |
+| CMake        |          3.17          |
+| spdlog       |        1.5.0-1         |
+| OpenCV       |        4.2.0-2         |
 
 ## Build & install
 

--- a/include/ctello.h
+++ b/include/ctello.h
@@ -16,6 +16,8 @@
 //
 //  You can contact the author via carlospzlz@gmail.com
 
+#pragma once
+
 #include <sys/socket.h>
 #include <sys/types.h>
 

--- a/include/ctello.h
+++ b/include/ctello.h
@@ -37,7 +37,7 @@ const char* const TELLO_SERVER_COMMAND_PORT{"8889"};
 // program to deliver datagrams to for a particular port.
 //
 // NOTE 2: Tello will respond to any port, but it keeps that port number
-// rememebered while it's powered up. So you can't have more than one client
+// remembered while it's powered up. So you can't have more than one client
 // receiving responses from the Tello.
 const int LOCAL_CLIENT_COMMAND_PORT{9000};
 

--- a/src/ctello.cpp
+++ b/src/ctello.cpp
@@ -53,7 +53,7 @@ spdlog::level::level_enum GetLogLevelFromEnv(const std::string& var_name)
     };
     // clang-format on
     const char* const name_c_str = std::getenv(var_name.c_str());
-    if (name_c_str == nullptr)
+    if (!name_c_str)
     {
         // Info is the default
         return spdlog::level::info;
@@ -97,7 +97,7 @@ std::pair<bool, std::string> FindSocketAddr(const char* const ip,
     hints.ai_socktype = SOCK_DGRAM;
     int result = getaddrinfo(ip, port, &hints, &result_list);
 
-    if (result != 0)
+    if (result)
     {
         std::stringstream ss;
         ss << "getaddrinfo: " << result;

--- a/src/ctello.cpp
+++ b/src/ctello.cpp
@@ -63,7 +63,7 @@ spdlog::level::level_enum GetLogLevelFromEnv(const std::string& var_name)
 }
 
 // Binds the given socket file descriptor ot the given port.
-// Returns whether it suceeds or not and the error message.
+// Returns whether it succeeds or not and the error message.
 std::pair<bool, std::string> BindSocketToPort(const int sockfd, const int port)
 {
     sockaddr_in listen_addr{};
@@ -86,7 +86,7 @@ std::pair<bool, std::string> BindSocketToPort(const int sockfd, const int port)
 }
 
 // Finds the socket address given an ip and a port.
-// Returns whether it suceeds or not and the error message.
+// Returns whether it succeeds or not and the error message.
 std::pair<bool, std::string> FindSocketAddr(const char* const ip,
                                             const char* const port,
                                             sockaddr_storage* const addr)

--- a/src/ctello_joystick.cpp
+++ b/src/ctello_joystick.cpp
@@ -137,7 +137,7 @@ private:
 
     void ProcessAxisEvent(const uint8_t number, const int16_t value)
     {
-        if (value == 0)
+        if (!value)
         {
             m_move_cmd.clear();
             return;


### PR DESCRIPTION
This PR adds `pragma once` to `ctello.h` preventing potential errors due to `ctello.h` being included multiple times.
I chose `pragma once` over include guards because it is well-supported across most compilers and speeds up compile time.
The PR also improves the code  by simplifying if-statements and fixing typos.